### PR TITLE
feat!: enable `Debug::fmt` to show the type name even in stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,5 @@ num-traits = { version = "0.2", default-features = false, optional = true }
 
 [features]
 default = ["std"]
-nightly = []
 std = []
 truncate = ["num-traits"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use core::hash::SipHasher as DefaultHasher;
 use core::fmt::{self, Debug, Formatter, LowerHex};
 use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
+use core::any::type_name;
 
 #[cfg(feature = "truncate")]
 pub use num_traits::AsPrimitive;
@@ -28,15 +29,6 @@ impl<T> AsPrimitive<T> for T {
     }
 }
 
-#[cfg(feature = "nightly")]
-fn type_name<T: ?Sized>() -> &'static str {
-    unsafe { core::intrinsics::type_name::<T>() }
-}
-
-#[cfg(not(feature = "nightly"))]
-fn type_name<T: ?Sized>() -> &'static str {
-    "?"
-}
 
 // TODO: be generic over Hasher
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 #![cfg_attr(not(feature = "std"), allow(deprecated))]
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
Use [`core::any::type_name`](https://doc.rust-lang.org/core/any/fn.type_name.html) instead of [`core::intrinsics::type_name`](https://doc.rust-lang.org/core/intrinsics/fn.type_name.html).

BREAKING CHANGE: the `nightly` feature is removed